### PR TITLE
Fix error in built application

### DIFF
--- a/src/createInstance.js
+++ b/src/createInstance.js
@@ -7,8 +7,6 @@ module.exports = function (rootModuleName, title, opts) {
   if (opts.pageFrom || opts.pageTo) rangeMode = true
 
   return function () {
-    // eslint-disable-next-line
-    const VUEX_PAGINATION_INSTANCE = true
     let store = this.$store
 
     let defaults = {

--- a/src/createInstance.js
+++ b/src/createInstance.js
@@ -6,7 +6,7 @@ module.exports = function (rootModuleName, title, opts) {
 
   if (opts.pageFrom || opts.pageTo) rangeMode = true
 
-  return function () {
+  let vuexPaginationGetter = function () {
     let store = this.$store
 
     let defaults = {
@@ -76,12 +76,6 @@ module.exports = function (rootModuleName, title, opts) {
     }
 
     return new Proxy({}, {
-      getOwnPropertyDescriptor (target, prop) {
-        if (prop === 'VUEX_PAGINATION') {
-          return { configurable: true, enumerable: true, value: true }
-        }
-        return undefined
-      },
       get,
       set,
       deleteProperty () {
@@ -103,4 +97,13 @@ module.exports = function (rootModuleName, title, opts) {
       }
     })
   }
+
+  Object.defineProperty(vuexPaginationGetter, '$_vuexPagination', {
+    value: true,
+    enumerable: false,
+    writable: false,
+    configurable: false
+  })
+
+  return vuexPaginationGetter
 }

--- a/src/createInstance.js
+++ b/src/createInstance.js
@@ -78,6 +78,12 @@ module.exports = function (rootModuleName, title, opts) {
     }
 
     return new Proxy({}, {
+      getOwnPropertyDescriptor (target, prop) {
+        if (prop === 'VUEX_PAGINATION') {
+          return { configurable: true, enumerable: true, value: true }
+        }
+        return undefined
+      },
       get,
       set,
       deleteProperty () {

--- a/src/index.js
+++ b/src/index.js
@@ -60,26 +60,27 @@ module.exports.PaginationPlugin = {
         })
 
         Object.keys(this._computedWatchers).forEach((key) => {
-          if (!this._computedWatchers[key].expression.includes('VUEX_PAGINATION_INSTANCE')) return
-          if (!this[key] || !this[key]._meta || typeof this[key]._meta !== 'object') return
-
-          let meta = this[key]._meta
-          let initialOpts = {
-            page: this[key].page,
-            pageSize: this[key].pageSize,
-            args: meta.initialArgs
-          }
-
-          if (typeof this.$store.getters[[getRootModuleName(), meta.storeModule, 'instance'].join('/')] === 'undefined') {
-            this.instanceQueue.push({
-              storeModuleName: meta.storeModule,
-              instanceId: this._uid + meta.id,
-              initialOpts
-            })
-            return
-          }
-
           Vue.nextTick(() => {
+            let descriptor = Object.getOwnPropertyDescriptor(this._computedWatchers[key].value, 'VUEX_PAGINATION')
+            if (!descriptor || descriptor.value !== true) return
+            if (!this[key] || !this[key]._meta || typeof this[key]._meta !== 'object') return
+
+            let meta = this[key]._meta
+            let initialOpts = {
+              page: this[key].page,
+              pageSize: this[key].pageSize,
+              args: meta.initialArgs
+            }
+
+            if (typeof this.$store.getters[[getRootModuleName(), meta.storeModule, 'instance'].join('/')] === 'undefined') {
+              this.instanceQueue.push({
+                storeModuleName: meta.storeModule,
+                instanceId: this._uid + meta.id,
+                initialOpts
+              })
+              return
+            }
+
             linkPaginatedResource(meta.storeModule, this._uid + meta.id, initialOpts)
           })
         })


### PR DESCRIPTION
As described in #11, if a Vue application is being built with `NODE_ENV=production`, vuex-pagination fails to work.

This is because of a change we introduced here: https://github.com/cyon/vuex-pagination/issues/4#issuecomment-497716005

The problem is the check we were using:
```javascript
if (!this._computedWatchers[key].expression.includes('VUEX_PAGINATION_INSTANCE')) return
```

It seems like in the production build, the `expression` is always empty. **Note to self:** always test with a production build, too.

I think i found a way how this can be solved using property descriptors. For that i added a property descriptor to our Proxy: https://github.com/cyon/vuex-pagination/blob/fix-build-error/src/createInstance.js#L81-L86

This is being checked in the Vue plugin here: https://github.com/cyon/vuex-pagination/blob/fix-build-error/src/index.js#L64

However, for it to work i had to do the check in `nextTick` which lead to most of the test cases fail. This probably needs some more testing before it can be merged.