### PR TITLE
pass the instance id in opts

### DIFF
--- a/src/createResource.js
+++ b/src/createResource.js
@@ -82,10 +82,10 @@ module.exports = function (name, fetchPage, opts) {
         })
 
         Object.keys(state.instances).map((id) => {
-          commit('setInstanceConfig', Object.assign({}, state.instances[id], { loading: true }))
+          commit('setInstanceConfig', Object.assign({}, state.instances[id], { id, loading: true }))
 
           dispatch('fetchPage', Object.assign({}, state.instances[id], { id })).then(() => {
-            commit('setInstanceConfig', Object.assign({}, state.instances[id], { loading: false }))
+            commit('setInstanceConfig', Object.assign({}, state.instances[id], { id, loading: false }))
           })
         })
       },


### PR DESCRIPTION
Hi @MaxGfeller ,
thanks so much for this library. I find it extremely useful.

What I experienced when playing with your library is that when I was doing a refresh in the vuex store there was an `undefined` instance being created (and living beside the proper one, doing unnecessary redundant calls from time to time)

I think that passing the `id` in refresh actions should fix the problem.

Looking forward to your acceptance of this PR.

Keep up the great job mate! 