### PR TITLE
Fix argsFn $watcher in range mode

### DIFF
--- a/examples/range-with-query/App.vue
+++ b/examples/range-with-query/App.vue
@@ -5,13 +5,6 @@
       <li v-for="item in licenses.items" :key="item.id">{{ item.id }}</li>
     </ul>
     <a @click="licenses.pageTo++">Load more...</a>
-    <pre>
-      page:     {{ licenses.page }}
-      pageFrom: {{ licenses.pageFrom }}
-      pageTo:   {{ licenses.pageTo }}
-      items:    {{ licenses.items.length }}
-      total:    {{ licenses.total }}
-    </pre>
   </div>
 </template>
 <script>

--- a/examples/range-with-query/App.vue
+++ b/examples/range-with-query/App.vue
@@ -1,0 +1,37 @@
+<template>
+  <div>
+    <input v-model="query" placeholder="Search for a license...">
+    <ul>
+      <li v-for="item in licenses.items" :key="item.id">{{ item.id }}</li>
+    </ul>
+    <a @click="licenses.pageTo++">Load more...</a>
+    <pre>
+      page:     {{ licenses.page }}
+      pageFrom: {{ licenses.pageFrom }}
+      pageTo:   {{ licenses.pageTo }}
+      items:    {{ licenses.items.length }}
+      total:    {{ licenses.total }}
+    </pre>
+  </div>
+</template>
+<script>
+import { createInstance } from '../../'
+
+export default {
+  data() {
+    return {
+      query: ''
+    }
+  },
+  computed: {
+    licenses: createInstance('licenses', {
+      pageFrom: 1,
+      args () {
+        return {
+          query: this.query,
+        }
+      },
+    })
+  }
+}
+</script>

--- a/examples/range-with-query/main.js
+++ b/examples/range-with-query/main.js
@@ -1,0 +1,22 @@
+import Vue from 'vue'
+import App from './App.vue'
+import Vuex from 'vuex'
+import { PaginationPlugin, createResource } from '../../'
+import { fetchPage } from '../_api/api-client'
+
+Vue.config.productionTip = false
+
+Vue.use(Vuex)
+Vue.use(PaginationPlugin)
+
+const store = new Vuex.Store({
+  strict: true
+})
+
+// Initialize resource
+createResource('licenses', fetchPage)
+
+new Vue({
+  render: h => h(App),
+  store
+}).$mount('#app')

--- a/examples/range-with-query/package.json
+++ b/examples/range-with-query/package.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "serve": "../../node_modules/.bin/vue-cli-service serve main.js"
+  }
+}

--- a/src/createInstance.js
+++ b/src/createInstance.js
@@ -27,11 +27,17 @@ module.exports = function (rootModuleName, title, opts) {
     let argsFn = (opts.args || (() => 'null')).bind(this)
 
     this.$watch(argsFn, (args) => {
-      store.dispatch([rootModuleName, title, 'updateInstance'].join('/'), {
+      const payload = {
         id: this._uid + instanceId,
-        page: 1,
         args
-      })
+      }
+      if (rangeMode) {
+        payload.pageFrom = 1
+        payload.pageTo = 1
+      } else {
+        payload.page = 1
+      }
+      store.dispatch([rootModuleName, title, 'updateInstance'].join('/'), payload)
     }, { deep: true })
 
     let initialArgs = argsFn()

--- a/test/createInstance.test.js
+++ b/test/createInstance.test.js
@@ -307,6 +307,10 @@ test('Base range functionality', async function () {
   expect(wrapper.vm.test.items.length).toBe(10)
   await nextTick()
 
+  expect(wrapper.vm.test.loading).toBe(false)
+  expect(wrapper.vm.test.pageFrom).toBe(1)
+  expect(wrapper.vm.test.pageTo).toBe(2)
+  expect(wrapper.vm.test.items.length).toBe(20)
   expect(wrapper.vm.test.items).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
 })
 

--- a/test/createInstance.test.js
+++ b/test/createInstance.test.js
@@ -360,6 +360,87 @@ test('Range mode and load multiple pages', async function () {
   expect(wrapper.vm.test.items).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 })
 
+test('Range mode with args fn', async function () {
+  let adapter = new TestAdapter()
+  adapter.nextResult = {
+    total: 33,
+    data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  }
+
+  const opts = {
+    pageFrom: 1,
+    pageTo: 1,
+    pageSize: 10,
+    args () {
+      return { counter: this.counter }
+    }
+  }
+
+  let component = {
+    data () {
+      return {
+        counter: 1
+      }
+    },
+    computed: {
+      test: createInstance('test12', opts)
+    },
+    render (h) {
+      return h('div')
+    }
+  }
+
+  let wrapper = createWrapper('test12', opts, component)
+  createResource('test12', adapter.fetchPage.bind(adapter))
+
+  expect(wrapper.vm.test.loading).toBe(true)
+  await nextTick()
+
+  expect(wrapper.vm.test.loading).toBe(false)
+  expect(wrapper.vm.test.items).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  expect(adapter.lastArgs.args).toEqual({ counter: 1 })
+  expect(wrapper.vm.test.pageFrom).toBe(1)
+  expect(wrapper.vm.test.pageTo).toBe(1)
+  expect(wrapper.vm.test.items.length).toBe(10)
+
+  adapter.nextResult = {
+    total: 33,
+    data: [11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+  }
+
+  wrapper.vm.test.pageTo = 2
+
+  expect(wrapper.vm.test.loading).toBe(true)
+  await nextTick()
+
+  expect(wrapper.vm.test.loading).toBe(false)
+  expect(wrapper.vm.test.pageFrom).toBe(1)
+  expect(wrapper.vm.test.pageTo).toBe(2)
+  expect(wrapper.vm.test.items.length).toBe(20)
+  expect(wrapper.vm.test.items).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+  expect(adapter.lastArgs.args).toEqual({ counter: 1 })
+
+  adapter.nextResult = {
+    total: 22,
+    data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  }
+
+  wrapper.vm.counter = 2
+
+  expect(wrapper.vm.test.loading).toBe(true)
+  expect(wrapper.vm.test.pageFrom).toBe(1)
+  expect(wrapper.vm.test.pageTo).toBe(1)
+  await nextTick()
+
+  expect(wrapper.vm.test.loading).toBe(false)
+  expect(wrapper.vm.test.pageFrom).toBe(1)
+  expect(wrapper.vm.test.pageTo).toBe(1)
+  expect(wrapper.vm.test.total).toBe(22)
+  expect(wrapper.vm.test.items.length).toBe(10)
+  expect(wrapper.vm.test.items).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  expect(adapter.lastArgs.args).toEqual({ counter: 2 })
+})
+
 test('Don\'t touch computed getters', async function () {
   let adapter = new TestAdapter()
   adapter.nextResult = {


### PR DESCRIPTION
The range mode gets disabled as soon as the `args()` output changes.
The properties `pageTo` and `pageFrom` become `undefined`, and `page` gets reset to `1`.
The page reset makes sense, as query and page are most likely coupled.
But the range mode itself should be inherited.

I added a (previously failing) test and an example to demonstrate the behaviour.

