### PR TITLE
Fix prefetching in range mode with args

### DIFF
--- a/examples/range-with-query-and-prefetch/App.vue
+++ b/examples/range-with-query-and-prefetch/App.vue
@@ -1,0 +1,30 @@
+<template>
+  <div>
+    <input v-model="query" placeholder="Search for a license...">
+    <ul>
+      <li v-for="item in licenses.items" :key="item.id">{{ item.id }}</li>
+    </ul>
+    <a @click="licenses.pageTo++">Load more...</a>
+  </div>
+</template>
+<script>
+import { createInstance } from '../../'
+
+export default {
+  data() {
+    return {
+      query: ''
+    }
+  },
+  computed: {
+    licenses: createInstance('licenses', {
+      pageFrom: 1,
+      args () {
+        return {
+          query: this.query,
+        }
+      },
+    })
+  }
+}
+</script>

--- a/examples/range-with-query-and-prefetch/main.js
+++ b/examples/range-with-query-and-prefetch/main.js
@@ -1,0 +1,22 @@
+import Vue from 'vue'
+import App from './App.vue'
+import Vuex from 'vuex'
+import { PaginationPlugin, createResource } from '../../'
+import { fetchPage } from '../_api/api-client'
+
+Vue.config.productionTip = false
+
+Vue.use(Vuex)
+Vue.use(PaginationPlugin)
+
+const store = new Vuex.Store({
+  strict: true
+})
+
+// Initialize resource
+createResource('licenses', fetchPage, { prefetch: true })
+
+new Vue({
+  render: h => h(App),
+  store
+}).$mount('#app')

--- a/examples/range-with-query-and-prefetch/package.json
+++ b/examples/range-with-query-and-prefetch/package.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "serve": "../../node_modules/.bin/vue-cli-service serve main.js"
+  }
+}

--- a/test/createInstance.test.js
+++ b/test/createInstance.test.js
@@ -441,6 +441,91 @@ test('Range mode with args fn', async function () {
   expect(adapter.lastArgs.args).toEqual({ counter: 2 })
 })
 
+test('Range mode with args fn and prefetch', async function () {
+  let adapter = new TestAdapter()
+  adapter.nextResult = {
+    total: 33,
+    data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  }
+
+  const opts = {
+    pageFrom: 1,
+    pageTo: 1,
+    pageSize: 10,
+    args () {
+      return { counter: this.counter }
+    }
+  }
+
+  let component = {
+    data () {
+      return {
+        counter: 1
+      }
+    },
+    computed: {
+      test: createInstance('test13', opts)
+    },
+    render (h) {
+      return h('div')
+    }
+  }
+
+  let wrapper = createWrapper('test13', opts, component)
+  createResource('test13', adapter.fetchPage.bind(adapter), { prefetch: true })
+
+  expect(wrapper.vm.test.loading).toBe(true)
+  await nextTick()
+
+  expect(wrapper.vm.test.loading).toBe(false)
+  expect(wrapper.vm.test.pageFrom).toBe(1)
+  expect(wrapper.vm.test.pageTo).toBe(1)
+  expect(wrapper.vm.test.total).toBe(33)
+  expect(wrapper.vm.test.items.length).toBe(10)
+  expect(wrapper.vm.test.items).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  expect(adapter.lastArgs.args).toEqual({ counter: 1 })
+
+  wrapper.vm.test.pageTo = 2
+
+  expect(wrapper.vm.test.loading).toBe(false)
+  expect(wrapper.vm.test.pageFrom).toBe(1)
+  expect(wrapper.vm.test.pageTo).toBe(2)
+  expect(wrapper.vm.test.total).toBe(33)
+  expect(wrapper.vm.test.items.length).toBe(20)
+  expect(wrapper.vm.test.items).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  expect(adapter.lastArgs.args).toEqual({ counter: 1 })
+
+  adapter.nextResult = {
+    total: 22,
+    data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  }
+
+  wrapper.vm.counter = 2
+
+  expect(wrapper.vm.test.loading).toBe(true)
+  expect(wrapper.vm.test.pageFrom).toBe(1)
+  expect(wrapper.vm.test.pageTo).toBe(1)
+  await nextTick()
+
+  expect(wrapper.vm.test.loading).toBe(false)
+  expect(wrapper.vm.test.pageFrom).toBe(1)
+  expect(wrapper.vm.test.pageTo).toBe(1)
+  expect(wrapper.vm.test.total).toBe(22)
+  expect(wrapper.vm.test.items.length).toBe(10)
+  expect(wrapper.vm.test.items).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  expect(adapter.lastArgs.args).toEqual({ counter: 2 })
+
+  wrapper.vm.test.pageTo = 2
+
+  expect(wrapper.vm.test.loading).toBe(false)
+  expect(wrapper.vm.test.pageFrom).toBe(1)
+  expect(wrapper.vm.test.pageTo).toBe(2)
+  expect(wrapper.vm.test.total).toBe(22)
+  expect(wrapper.vm.test.items.length).toBe(20)
+  expect(wrapper.vm.test.items).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  expect(adapter.lastArgs.args).toEqual({ counter: 2 })
+})
+
 test('Don\'t touch computed getters', async function () {
   let adapter = new TestAdapter()
   adapter.nextResult = {


### PR DESCRIPTION
Prefetching in range mode has the issue that `opts.page` is `NaN` on the prefetched call of the `fetchPage()` function.
I wrote a failing test and a fix, but the test [does not succeed](https://travis-ci.com/github/lukasbesch/vuex-pagination/jobs/355344055#L222) yet.
The example seems to be working though.

For the test:
I think another call of `nextTick()` is necessary (before changing `pageTo`) to allow the second promise to resolve.
But that alone does not work yet.